### PR TITLE
fix issue with multiline comments that end on the same line

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -520,7 +520,14 @@ func (s *Scanner) scanComment(ch rune) rune {
 							MultiEnded = true
 							isSingle = false
 							isMulti = false
-							return Comment
+							if s.Match != "" {
+								if strings.Contains(s.CommentStatusMultiAll[v], s.Match) {
+									s.CommentStatusMultiEnd[v] = ""
+									return Comment
+								}
+							} else {
+								s.CommentStatusMultiEnd[v] = ""
+							}
 						}
 						for !MultiEnded {
 							if len(s.CommentStatusMultiEnd[v]) < len(Extensions[v].endMulti) {

--- a/tests/test.html
+++ b/tests/test.html
@@ -1,5 +1,6 @@
 <head>
 <html>
+<!-- some unincluded comment -->
 <!-- @todo some comment -->
 
 <script>


### PR DESCRIPTION
multiline comments that ended on the same line were not checked to ensure they included the match string, this has been fixed and a test put in place to ensure it continues working.